### PR TITLE
Add Express server for Wake-on-LAN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Wake-on-LAN Server
+
+Simple ExpressJS server that exposes a `/wake` endpoint to send Wake-on-LAN packets.
+
+## Install
+
+```bash
+npm install
+```
+
+## Run
+
+```bash
+npm start
+```
+
+Server listens on port `3000` by default.
+
+## Usage
+
+Send a POST request to `/wake` with JSON body containing `mac` address.
+
+```bash
+curl -X POST http://localhost:3000/wake \
+  -H "Content-Type: application/json" \
+  -d '{"mac":"AA:BB:CC:DD:EE:FF"}'
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test_codex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "wol": "^1.0.7"
+  }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,0 @@
-echo "# test_codex" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/ishaankarnik11/test_codex.git
-git push -u origin main

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const wol = require('wol');
+
+const app = express();
+app.use(express.json());
+
+app.post('/wake', async (req, res) => {
+  const { mac } = req.body;
+  if (!mac) {
+    return res.status(400).json({ error: 'MAC address is required' });
+  }
+  try {
+    await wol.wake(mac);
+    res.json({ status: 'Magic packet sent', mac });
+  } catch (err) {
+    console.error('Failed to send WOL packet:', err);
+    res.status(500).json({ error: 'Failed to send WOL packet' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`WOL server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create server.js with `/wake` endpoint that sends magic packet using `wol`
- add package.json and `.gitignore`
- add README with usage instructions
- remove old readme.txt

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` (manual run)

------
https://chatgpt.com/codex/tasks/task_e_684c16fb7f708320b746d8f9f10e6181