### PR TITLE
Add device management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,31 @@ curl -X POST http://localhost:3000/wake \
   -H "Content-Type: application/json" \
   -d '{"mac":"AA:BB:CC:DD:EE:FF"}'
 ```
+
+## Device Management
+
+Three additional endpoints are available to manage devices in memory. A device
+requires a `name` and `mac` address. An optional `ip` address can also be
+provided.
+
+### Add a Device
+
+```bash
+curl -X POST http://localhost:3000/device \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Desktop","mac":"AA:BB:CC:DD:EE:FF","ip":"192.168.0.10"}'
+```
+
+### Update a Device
+
+```bash
+curl -X PUT http://localhost:3000/device/Desktop \
+  -H "Content-Type: application/json" \
+  -d '{"mac":"AA:BB:CC:DD:EE:11","ip":"192.168.0.11"}'
+```
+
+### Delete a Device
+
+```bash
+curl -X DELETE http://localhost:3000/device/Desktop
+```

--- a/server.js
+++ b/server.js
@@ -4,6 +4,9 @@ const wol = require('wol');
 const app = express();
 app.use(express.json());
 
+// In-memory device store
+const devices = {};
+
 app.post('/wake', async (req, res) => {
   const { mac } = req.body;
   if (!mac) {
@@ -16,6 +19,45 @@ app.post('/wake', async (req, res) => {
     console.error('Failed to send WOL packet:', err);
     res.status(500).json({ error: 'Failed to send WOL packet' });
   }
+});
+
+// Add a new device
+app.post('/device', (req, res) => {
+  const { name, mac, ip } = req.body;
+  if (!name || !mac) {
+    return res
+      .status(400)
+      .json({ error: 'Device name and MAC address are required' });
+  }
+  devices[name] = { name, mac, ip };
+  res.json({ status: 'Device added', device: devices[name] });
+});
+
+// Update an existing device
+app.put('/device/:name', (req, res) => {
+  const { name } = req.params;
+  const { mac, ip } = req.body;
+  if (!mac) {
+    return res
+      .status(400)
+      .json({ error: 'MAC address is required for update' });
+  }
+  if (!devices[name]) {
+    return res.status(404).json({ error: 'Device not found' });
+  }
+  devices[name] = { name, mac, ip };
+  res.json({ status: 'Device updated', device: devices[name] });
+});
+
+// Delete a device
+app.delete('/device/:name', (req, res) => {
+  const { name } = req.params;
+  if (!devices[name]) {
+    return res.status(404).json({ error: 'Device not found' });
+  }
+  const removed = devices[name];
+  delete devices[name];
+  res.json({ status: 'Device deleted', device: removed });
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add in-memory device store with CRUD endpoints
- document new `/device` endpoints for add, update and delete

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a2e03fc8320bd500e6f3aab6cbd