### PR TITLE
Persist devices in MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ npm install
 npm start
 ```
 
+The server expects a MongoDB instance running locally at
+`mongodb://localhost:27017/wol`. You can override this by setting the
+`MONGODB_URI` environment variable before starting the server.
+
 Server listens on port `3000` by default.
 
 ## Usage
@@ -28,9 +32,9 @@ curl -X POST http://localhost:3000/wake \
 
 ## Device Management
 
-Three additional endpoints are available to manage devices in memory. A device
-requires a `name` and `mac` address. An optional `ip` address can also be
-provided.
+Three additional endpoints are available to manage devices. Device information
+is persisted in a MongoDB database. A device requires a `name` and `mac`
+address. An optional `ip` address can also be provided.
 
 ### Add a Device
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",
+    "mongoose": "^8.15.2",
     "wol": "^1.0.7"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,11 +1,23 @@
 const express = require('express');
 const wol = require('wol');
+const mongoose = require('mongoose');
 
 const app = express();
 app.use(express.json());
 
-// In-memory device store
-const devices = {};
+// MongoDB connection
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/wol', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+const deviceSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  mac: { type: String, required: true },
+  ip: String,
+});
+
+const Device = mongoose.model('Device', deviceSchema);
 
 app.post('/wake', async (req, res) => {
   const { mac } = req.body;
@@ -22,19 +34,27 @@ app.post('/wake', async (req, res) => {
 });
 
 // Add a new device
-app.post('/device', (req, res) => {
+app.post('/device', async (req, res) => {
   const { name, mac, ip } = req.body;
   if (!name || !mac) {
     return res
       .status(400)
       .json({ error: 'Device name and MAC address are required' });
   }
-  devices[name] = { name, mac, ip };
-  res.json({ status: 'Device added', device: devices[name] });
+  try {
+    const device = await Device.create({ name, mac, ip });
+    res.json({ status: 'Device added', device });
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ error: 'Device already exists' });
+    }
+    console.error('Failed to add device:', err);
+    res.status(500).json({ error: 'Failed to add device' });
+  }
 });
 
 // Update an existing device
-app.put('/device/:name', (req, res) => {
+app.put('/device/:name', async (req, res) => {
   const { name } = req.params;
   const { mac, ip } = req.body;
   if (!mac) {
@@ -42,22 +62,35 @@ app.put('/device/:name', (req, res) => {
       .status(400)
       .json({ error: 'MAC address is required for update' });
   }
-  if (!devices[name]) {
-    return res.status(404).json({ error: 'Device not found' });
+  try {
+    const device = await Device.findOneAndUpdate(
+      { name },
+      { mac, ip, name },
+      { new: true }
+    );
+    if (!device) {
+      return res.status(404).json({ error: 'Device not found' });
+    }
+    res.json({ status: 'Device updated', device });
+  } catch (err) {
+    console.error('Failed to update device:', err);
+    res.status(500).json({ error: 'Failed to update device' });
   }
-  devices[name] = { name, mac, ip };
-  res.json({ status: 'Device updated', device: devices[name] });
 });
 
 // Delete a device
-app.delete('/device/:name', (req, res) => {
+app.delete('/device/:name', async (req, res) => {
   const { name } = req.params;
-  if (!devices[name]) {
-    return res.status(404).json({ error: 'Device not found' });
+  try {
+    const device = await Device.findOneAndDelete({ name });
+    if (!device) {
+      return res.status(404).json({ error: 'Device not found' });
+    }
+    res.json({ status: 'Device deleted', device });
+  } catch (err) {
+    console.error('Failed to delete device:', err);
+    res.status(500).json({ error: 'Failed to delete device' });
   }
-  const removed = devices[name];
-  delete devices[name];
-  res.json({ status: 'Device deleted', device: removed });
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- connect to MongoDB via mongoose
- store device info using a `Device` model
- add MongoDB dependency
- document the new MongoDB requirement

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b1ece5883209cd5b658e53d768a