### PR TITLE
Add REST API for device and activity management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Wake-on-LAN Server
 
-Simple ExpressJS server that exposes a `/wake` endpoint to send Wake-on-LAN packets.
+Simple ExpressJS server that exposes endpoints to manage devices, log activity
+and send Wake-on-LAN packets.
 
 ## Install
 
@@ -22,7 +23,7 @@ Server listens on port `3000` by default.
 
 ## Usage
 
-Send a POST request to `/wake` with JSON body containing `mac` address.
+Send a POST request to `/wake` with JSON body containing `macAddress`.
 
 ```bash
 curl -X POST http://localhost:3000/wake \
@@ -32,16 +33,16 @@ curl -X POST http://localhost:3000/wake \
 
 ## Device Management
 
-Three additional endpoints are available to manage devices. Device information
-is persisted in a MongoDB database. A device requires a `name` and `mac`
-address. An optional `ip` address can also be provided.
+Several endpoints are available to manage devices. Device information
+is persisted in a MongoDB database. A device requires a `name` and `macAddress`.
+An optional `ipAddress`, `description` and `group` can also be provided.
 
 ### Add a Device
 
 ```bash
 curl -X POST http://localhost:3000/device \
   -H "Content-Type: application/json" \
-  -d '{"name":"Desktop","mac":"AA:BB:CC:DD:EE:FF","ip":"192.168.0.10"}'
+  -d '{"name":"Desktop","macAddress":"AA:BB:CC:DD:EE:FF","ipAddress":"192.168.0.10"}'
 ```
 
 ### Update a Device
@@ -49,7 +50,7 @@ curl -X POST http://localhost:3000/device \
 ```bash
 curl -X PUT http://localhost:3000/device/Desktop \
   -H "Content-Type: application/json" \
-  -d '{"mac":"AA:BB:CC:DD:EE:11","ip":"192.168.0.11"}'
+  -d '{"macAddress":"AA:BB:CC:DD:EE:11","ipAddress":"192.168.0.11"}'
 ```
 
 ### Delete a Device
@@ -57,3 +58,22 @@ curl -X PUT http://localhost:3000/device/Desktop \
 ```bash
 curl -X DELETE http://localhost:3000/device/Desktop
 ```
+
+## REST API
+
+The server also exposes a set of `/api/*` endpoints more suitable for
+front‑end applications.
+
+* `GET /api/health` – health check.
+* `GET /api/devices` – list devices.
+* `GET /api/devices/{id}` – fetch a single device.
+* `POST /api/devices` – create a device.
+* `PUT /api/devices/{id}` – update a device.
+* `DELETE /api/devices/{id}` – remove a device.
+* `POST /api/devices/{id}/wake` – send Wake‑on‑LAN for a device.
+* `POST /api/devices/bulk-wake` – wake multiple devices.
+* `GET /api/activities` – list activity records.
+* `POST /api/activities` – record an activity.
+* `DELETE /api/activities` – clear activity records.
+* `GET /api/activities/{id}` – get a single activity entry.
+* `GET /api/groups` – list available groups.

--- a/server.js
+++ b/server.js
@@ -13,20 +13,30 @@ mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/wol', {
 
 const deviceSchema = new mongoose.Schema({
   name: { type: String, required: true, unique: true },
-  mac: { type: String, required: true },
-  ip: String,
+  macAddress: { type: String, required: true },
+  ipAddress: String,
+  description: String,
+  group: String,
+});
+
+const activitySchema = new mongoose.Schema({
+  device: { type: mongoose.Schema.Types.ObjectId, ref: 'Device' },
+  action: { type: String, required: true },
+  status: String,
+  createdAt: { type: Date, default: Date.now },
 });
 
 const Device = mongoose.model('Device', deviceSchema);
+const Activity = mongoose.model('Activity', activitySchema);
 
 app.post('/wake', async (req, res) => {
-  const { mac } = req.body;
-  if (!mac) {
+  const { macAddress } = req.body;
+  if (!macAddress) {
     return res.status(400).json({ error: 'MAC address is required' });
   }
   try {
-    await wol.wake(mac);
-    res.json({ status: 'Magic packet sent', mac });
+    await wol.wake(macAddress);
+    res.json({ status: 'Magic packet sent', macAddress });
   } catch (err) {
     console.error('Failed to send WOL packet:', err);
     res.status(500).json({ error: 'Failed to send WOL packet' });
@@ -35,14 +45,20 @@ app.post('/wake', async (req, res) => {
 
 // Add a new device
 app.post('/device', async (req, res) => {
-  const { name, mac, ip } = req.body;
-  if (!name || !mac) {
+  const { name, macAddress, ipAddress, description, group } = req.body;
+  if (!name || !macAddress) {
     return res
       .status(400)
       .json({ error: 'Device name and MAC address are required' });
   }
   try {
-    const device = await Device.create({ name, mac, ip });
+    const device = await Device.create({
+      name,
+      macAddress,
+      ipAddress,
+      description,
+      group,
+    });
     res.json({ status: 'Device added', device });
   } catch (err) {
     if (err.code === 11000) {
@@ -56,8 +72,8 @@ app.post('/device', async (req, res) => {
 // Update an existing device
 app.put('/device/:name', async (req, res) => {
   const { name } = req.params;
-  const { mac, ip } = req.body;
-  if (!mac) {
+  const { macAddress, ipAddress, description, group } = req.body;
+  if (!macAddress) {
     return res
       .status(400)
       .json({ error: 'MAC address is required for update' });
@@ -65,7 +81,7 @@ app.put('/device/:name', async (req, res) => {
   try {
     const device = await Device.findOneAndUpdate(
       { name },
-      { mac, ip, name },
+      { macAddress, ipAddress, name, description, group },
       { new: true }
     );
     if (!device) {
@@ -90,6 +106,184 @@ app.delete('/device/:name', async (req, res) => {
   } catch (err) {
     console.error('Failed to delete device:', err);
     res.status(500).json({ error: 'Failed to delete device' });
+  }
+});
+
+// Health check
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+// REST-like device management
+app.get('/api/devices', async (req, res) => {
+  const devices = await Device.find();
+  res.json(devices);
+});
+
+app.get('/api/devices/:id', async (req, res) => {
+  try {
+    const device = await Device.findById(req.params.id);
+    if (!device) {
+      return res.status(404).json({ error: 'Device not found' });
+    }
+    res.json(device);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to retrieve device' });
+  }
+});
+
+app.post('/api/devices', async (req, res) => {
+  const { name, macAddress, ipAddress, description, group } = req.body;
+  if (!name || !macAddress) {
+    return res
+      .status(400)
+      .json({ error: 'Device name and MAC address are required' });
+  }
+  try {
+    const device = await Device.create({
+      name,
+      macAddress,
+      ipAddress,
+      description,
+      group,
+    });
+    res.status(201).json(device);
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ error: 'Device already exists' });
+    }
+    res.status(500).json({ error: 'Failed to create device' });
+  }
+});
+
+app.put('/api/devices/:id', async (req, res) => {
+  const { name, macAddress, ipAddress, description, group } = req.body;
+  try {
+    const device = await Device.findByIdAndUpdate(
+      req.params.id,
+      { name, macAddress, ipAddress, description, group },
+      { new: true }
+    );
+    if (!device) {
+      return res.status(404).json({ error: 'Device not found' });
+    }
+    res.json(device);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update device' });
+  }
+});
+
+app.delete('/api/devices/:id', async (req, res) => {
+  try {
+    const device = await Device.findByIdAndDelete(req.params.id);
+    if (!device) {
+      return res.status(404).json({ error: 'Device not found' });
+    }
+    res.json({ status: 'Device deleted', device });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to delete device' });
+  }
+});
+
+app.post('/api/devices/:id/wake', async (req, res) => {
+  try {
+    const device = await Device.findById(req.params.id);
+    if (!device) {
+      return res.status(404).json({ error: 'Device not found' });
+    }
+    await wol.wake(device.macAddress);
+    await Activity.create({
+      device: device._id,
+      action: 'wake',
+      status: 'sent',
+    });
+    res.json({ status: 'Magic packet sent', device });
+  } catch (err) {
+    console.error('Failed to send WOL packet:', err);
+    res.status(500).json({ error: 'Failed to send WOL packet' });
+  }
+});
+
+app.post('/api/devices/bulk-wake', async (req, res) => {
+  const { ids } = req.body;
+  if (!Array.isArray(ids)) {
+    return res.status(400).json({ error: 'ids must be an array' });
+  }
+  const results = [];
+  for (const id of ids) {
+    try {
+      const device = await Device.findById(id);
+      if (!device) {
+        results.push({ id, error: 'not found' });
+        continue;
+      }
+      await wol.wake(device.macAddress);
+      await Activity.create({
+        device: device._id,
+        action: 'wake',
+        status: 'sent',
+      });
+      results.push({ id, status: 'sent' });
+    } catch (err) {
+      results.push({ id, error: 'failed' });
+    }
+  }
+  res.json({ results });
+});
+
+app.get('/api/groups', async (req, res) => {
+  const groups = await Device.distinct('group');
+  res.json(groups.filter(Boolean));
+});
+
+app.get('/api/activities', async (req, res) => {
+  const { device, status, start, end } = req.query;
+  const query = {};
+  if (device) query.device = device;
+  if (status) query.status = status;
+  if (start || end) {
+    query.createdAt = {};
+    if (start) query.createdAt.$gte = new Date(start);
+    if (end) query.createdAt.$lte = new Date(end);
+  }
+  const activities = await Activity.find(query).populate('device');
+  res.json(activities);
+});
+
+app.post('/api/activities', async (req, res) => {
+  const { device, action, status } = req.body;
+  if (!action) {
+    return res.status(400).json({ error: 'Action is required' });
+  }
+  try {
+    const activity = await Activity.create({ device, action, status });
+    res.status(201).json(activity);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create activity' });
+  }
+});
+
+app.delete('/api/activities', async (req, res) => {
+  const { device } = req.query;
+  const query = {};
+  if (device) query.device = device;
+  try {
+    const result = await Activity.deleteMany(query);
+    res.json({ deleted: result.deletedCount });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to delete activities' });
+  }
+});
+
+app.get('/api/activities/:id', async (req, res) => {
+  try {
+    const activity = await Activity.findById(req.params.id).populate('device');
+    if (!activity) {
+      return res.status(404).json({ error: 'Activity not found' });
+    }
+    res.json(activity);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to retrieve activity' });
   }
 });
 


### PR DESCRIPTION
## Summary
- expand `server.js` to implement REST-like API endpoints
- log wake events and allow activity queries
- support groups and extra device metadata
- provide a health check route
- update `README` with instructions for the new API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c242d72f88320ab14d398fe436cc1